### PR TITLE
Support for writing single element arrays as json arrays (2/3)

### DIFF
--- a/src/main/java/com/theoryinpractise/halbuilder/json/JsonRepresentationWriter.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/json/JsonRepresentationWriter.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -54,6 +55,10 @@ public class JsonRepresentationWriter implements RepresentationWriter<String> {
         if (flags.contains(RepresentationFactory.STRIP_NULLS)) {
             codec.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         }
+        //if SINGLE_ELEM_ARRAYS is set, write arrays with one element as an array
+        //rather than a single value.
+        codec.configure(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED, 
+                        !flags.contains(RepresentationFactory.SINGLE_ELEM_ARRAYS));
         f.setCodec(codec);
         f.enable(JsonGenerator.Feature.QUOTE_FIELD_NAMES);
         return f;

--- a/src/test/java/com/theoryinpractise/halbuilder/json/RenderingTest.java
+++ b/src/test/java/com/theoryinpractise/halbuilder/json/RenderingTest.java
@@ -41,6 +41,8 @@ public class RenderingTest {
     private String exampleWithMultipleNestedSubresourcesJson;
     private String exampleWithTemplateJson;
     private String exampleWithArray;
+    private String exampleWithSingleElemArray;
+    private String exampleWithSingleElemArrayValue;
 
     @BeforeMethod
     public void setup() throws IOException {
@@ -63,6 +65,10 @@ public class RenderingTest {
         exampleWithTemplateJson = Resources.toString(RenderingTest.class.getResource("/exampleWithTemplate.json"), Charsets.UTF_8)
                 .trim();
         exampleWithArray = Resources.toString(RenderingTest.class.getResource("/exampleWithArray.json"), Charsets.UTF_8)
+                .trim();
+        exampleWithSingleElemArray = Resources.toString(RenderingTest.class.getResource("/exampleWithSingleElemArray.json"), Charsets.UTF_8)
+                .trim();
+        exampleWithSingleElemArrayValue = Resources.toString(RenderingTest.class.getResource("/exampleWithSingleElemArrayValue.json"), Charsets.UTF_8)
                 .trim();
     }
 
@@ -327,6 +333,35 @@ public class RenderingTest {
 
     }
 
+    @Test
+    public void testHalWithSingleElemArray() {
+
+        String representation = new JsonRepresentationFactory()
+                .withFlag(RepresentationFactory.PRETTY_PRINT)
+                .withFlag(RepresentationFactory.SINGLE_ELEM_ARRAYS)
+                .newRepresentation()
+                .withProperty("name", "Example Resource")
+                .withProperty("array", ImmutableList.of("one"))
+                .toString(RepresentationFactory.HAL_JSON);
+
+        assertThat(representation).isEqualTo(exampleWithSingleElemArray);
+
+    }   
+
+    @Test
+    public void testHalWithSingleElemArrayValue() {
+
+        String representation = new JsonRepresentationFactory()
+                .withFlag(RepresentationFactory.PRETTY_PRINT)
+                .newRepresentation()
+                .withProperty("name", "Example Resource")
+                .withProperty("array", ImmutableList.of("one"))
+                .toString(RepresentationFactory.HAL_JSON);
+
+        assertThat(representation).isEqualTo(exampleWithSingleElemArrayValue);
+
+    }   
+    
     public static class Phone {
         private final Integer id;
 


### PR DESCRIPTION
There are three total pull requests as three separate repos are affected, all contain the same description below.

Adds support for serializing single element arrays as json arrays rather than unwrapping them into values.  This is something I have run into frequently, particularly when interfacing with services written in other languages.

This is a fairly simple change implemented similarly to STRIP_NULLS, a new flag was added to RepresentationFactory, SINGLE_ELEM_ARRAYS that when set will serialize collections containing a single element as a json array rather than a value using the WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED serialization feature in jackson.

New tests were added to halbuilder-json to test serializing single element arrays with and without SINGLE_ELEM_ARRAYS.   New example files were added to halbuilder-test-resources to support the tests.
