### PR TITLE
Allow passing ObjectMapper to constructor of JsonRepresentationReader/Writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 *.iml
+.idea

--- a/src/main/java/com/theoryinpractise/halbuilder/json/JsonRepresentationFactory.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/json/JsonRepresentationFactory.java
@@ -1,13 +1,44 @@
 package com.theoryinpractise.halbuilder.json;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.theoryinpractise.halbuilder.DefaultRepresentationFactory;
+import com.theoryinpractise.halbuilder.api.ContentRepresentation;
+import com.theoryinpractise.halbuilder.api.RepresentationWriter;
+import com.theoryinpractise.halbuilder.impl.ContentType;
+
+import java.io.Reader;
 
 /**
  * Simple representation factory configured for JSON usage.
  */
-public class JsonRepresentationFactory extends DefaultRepresentationFactory {
-    public JsonRepresentationFactory() {
-        withRenderer(HAL_JSON, JsonRepresentationWriter.class);
-        withReader(HAL_JSON, JsonRepresentationReader.class);
+public class JsonRepresentationFactory
+    extends DefaultRepresentationFactory {
+
+  private ObjectMapper mapper;
+
+  public JsonRepresentationFactory() {
+    this(null);
+  }
+
+  public JsonRepresentationFactory(ObjectMapper mapper) {
+    withRenderer(HAL_JSON, JsonRepresentationWriter.class);
+    withReader(HAL_JSON, JsonRepresentationReader.class);
+    this.mapper = mapper;
+  }
+
+  @Override
+  public ContentRepresentation readRepresentation(String contentType, Reader reader) {
+    if (mapper != null && new ContentType(contentType).matches(HAL_JSON)) {
+      return new JsonRepresentationReader(this, mapper).read(reader);
     }
+    return super.readRepresentation(contentType, reader);
+  }
+
+  @Override
+  public RepresentationWriter<String> lookupRenderer(String contentType) {
+    if (mapper != null && new ContentType(contentType).matches(HAL_JSON)) {
+      return new JsonRepresentationWriter(mapper);
+    }
+    return super.lookupRenderer(contentType);
+  }
 }

--- a/src/main/java/com/theoryinpractise/halbuilder/json/JsonRepresentationReader.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/json/JsonRepresentationReader.java
@@ -35,8 +35,12 @@ public class JsonRepresentationReader implements RepresentationReader {
   private final AbstractRepresentationFactory representationFactory;
 
   public JsonRepresentationReader(AbstractRepresentationFactory representationFactory) {
+    this(representationFactory, new ObjectMapper());
+  }
+
+  public JsonRepresentationReader(AbstractRepresentationFactory representationFactory, ObjectMapper mapper) {
     this.representationFactory = representationFactory;
-    this.mapper = new ObjectMapper();
+    this.mapper = mapper;
   }
 
   public ContentRepresentation read(Reader reader) {

--- a/src/main/java/com/theoryinpractise/halbuilder/json/JsonRepresentationWriter.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/json/JsonRepresentationWriter.java
@@ -27,6 +27,16 @@ import static com.theoryinpractise.halbuilder.impl.api.Support.*;
 
 public class JsonRepresentationWriter implements RepresentationWriter<String> {
 
+    private final ObjectMapper mapper;
+
+    public JsonRepresentationWriter() {
+        this(new ObjectMapper());
+    }
+
+    public JsonRepresentationWriter(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
     public void write(ReadableRepresentation representation, Set<URI> flags, Writer writer) {
 
         try {
@@ -51,7 +61,7 @@ public class JsonRepresentationWriter implements RepresentationWriter<String> {
 
     protected JsonFactory getJsonFactory(Set<URI> flags) {
         JsonFactory f = new JsonFactory();
-        ObjectMapper codec = new ObjectMapper();
+        ObjectMapper codec = this.mapper.copy();
         if (flags.contains(RepresentationFactory.STRIP_NULLS)) {
             codec.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         }


### PR DESCRIPTION
This should support #2 and prepares for halbuilder/halbuilder-jaxrs#8.
